### PR TITLE
fix: style lists items in content

### DIFF
--- a/_sass/main.scss
+++ b/_sass/main.scss
@@ -87,3 +87,18 @@ h1.page-title {
 p.rss-subscribe {
     margin: 0;
 }
+.container-content ul {
+    padding-left: 20px;
+
+    ul li {
+        list-style-type: circle!important;
+
+        ul li {
+            list-style-type: square!important;
+        }
+    }
+
+    li {
+        list-style-type: disc!important;
+    }
+}


### PR DESCRIPTION
This will style lists inside content like github does, see the list after 'best practices' from https://devguide.calconnect.org/Scheduling/iMIP/  vs https://github.com/CalConnect/DEVGUIDE/blob/master/_pages/Scheduling/iMIP.md