### PR TITLE
Use direct link to github pages site (agendav.org domain name has new, unrelated owner)

### DIFF
--- a/_pages/CalDAV/Client-Implementations.md
+++ b/_pages/CalDAV/Client-Implementations.md
@@ -25,7 +25,7 @@ CalConnect only provides a list of known implementations of CalDAV clients. Any 
 
 aCal is a CalDAV client for Android which requires a CalDAV server to function.
 
-### [AgenDAV](http://agendav.org/)
+### [AgenDAV](https://agendav.github.io/agendav/)
 **Open Source/multilanguage**
 
 AgenDAV is an open source multilanguage CalDAV web client which features a rich AJAX interface with shared calendars support.


### PR DESCRIPTION
This change is mentioned in the Agendav repo here: https://github.com/agendav/agendav/issues/273