### PR TITLE
Add iCalDAV Kotlin library to CalDAV libraries

### DIFF
--- a/_pages/CalDAV/libraries.md
+++ b/_pages/CalDAV/libraries.md
@@ -48,6 +48,11 @@ A Ruby library to parse and generate iCalendar files.
 ### [ical.js](http://mozilla-comm.github.io/ical.js/)
 jsical - Javascript parser for rfc5545
 
+### [iCalDAV](https://github.com/iCalDAV/iCalDAV)
+**Open source/Kotlin**
+
+A Kotlin CalDAV client library with offline sync and conflict resolution. Features include RFC 5545 compliant iCalendar parsing (VEVENT, VTODO, VJOURNAL), CalDAV client with automatic server discovery, WebDAV ACL support (RFC 3744), recurring events with RRULE/RDATE/EXDATE expansion, and a sync engine with offline support. Includes an Android module for CalendarContract integration. Available on [Maven Central](https://central.sonatype.com/namespace/org.onekash).
+
 ### [IT Hit WebDAV Server Engine for .NET](https://www.webdavsystem.com/server/)
 **Commercial License**
 


### PR DESCRIPTION
## Summary

This PR adds [iCalDAV](https://github.com/iCalDAV/iCalDAV) to the list of CalDAV libraries.

## About iCalDAV

iCalDAV is a Kotlin CalDAV client library published on Maven Central under the `org.onekash` group. Key features include:

- **RFC 5545 compliant** iCalendar parsing and generation (VEVENT, VTODO, VJOURNAL)
- **CalDAV client** with automatic server discovery
- **WebDAV ACL support** (RFC 3744)
- **Recurring events** with full RRULE/RDATE/EXDATE expansion
- **Sync engine** with offline support and conflict resolution
- **Android module** for CalendarContract integration
- Tested with iCloud, Nextcloud, Radicale, and Baikal servers

## Links

- GitHub: https://github.com/iCalDAV/iCalDAV
- Maven Central: https://central.sonatype.com/namespace/org.onekash
- License: Apache 2.0