### PR TITLE
Add Resources sidebar section

### DIFF
--- a/_data/navigation_sidebar.yml
+++ b/_data/navigation_sidebar.yml
@@ -199,3 +199,20 @@ sections:
       - type: link
         label: Overview
         url: /calendar-spam/
+
+  - id: resources
+    match: "/resources"
+    title: Resources
+    items:
+      - type: link
+        label: Glossary
+        url: /resources/glossary/
+      - type: link
+        label: Standards
+        url: /resources/standards/
+      - type: link
+        label: Examples
+        url: /resources/examples/
+      - type: link
+        label: Links
+        url: /resources/links/


### PR DESCRIPTION
Adds a `resources` section to `navigation_sidebar.yml` so that `/resources/*` pages (Glossary, Standards, Examples, Links) show the sidebar navigation instead of losing it.

Without this, the conditional sidebar logic hides the sidebar entirely on these pages.